### PR TITLE
Refactor menu logic

### DIFF
--- a/src/Frozennode/Administrator/Menu.php
+++ b/src/Frozennode/Administrator/Menu.php
@@ -51,6 +51,9 @@ class Menu {
 		//iterate over the menu to build the return array of valid menu items
 		foreach ($subMenu as $key => $item)
 		{
+            if (is_callable($item)) {
+                $item = call_user_func($item);
+            }
 			//if the item is a string, find its config
 			if (is_string($item))
 			{

--- a/src/Frozennode/Administrator/Menu.php
+++ b/src/Frozennode/Administrator/Menu.php
@@ -60,12 +60,17 @@ class Menu {
 				//if a config object was returned and if the permission passes, add the item to the menu
 				if (is_a($config, 'Frozennode\Administrator\Config\Config') && $config->getOption('permission'))
 				{
-					$menu[$item] = $config->getOption('title');
+                    $this->add($menu, $item, $config->getOption('title'));
 				}
 				//otherwise if this is a custom page, add it to the menu
 				else if ($config === true)
 				{
-					$menu[$item] = $key;
+                    $this->add($menu, $item, $key);
+				}
+				//or if the variable $item is a valid URL
+				else if (filter_var($item, FILTER_VALIDATE_URL))
+				{
+                    $this->add($menu, $item, $key);
 				}
 			}
 			//if the item is an array, recursively run this method on it
@@ -83,4 +88,25 @@ class Menu {
 
 		return $menu;
 	}
+
+    /**
+     * @param array $menu
+     * @param string $item
+     * @param $key
+     */
+    protected function add(array &$menu, string $item, $key): void
+    {
+        $settingsPrefix = $this->configFactory->getSettingsPrefix();
+        $pagePrefix = $this->configFactory->getPagePrefix();
+        if (strpos($item, $settingsPrefix) === 0) {
+            $url = route('admin_settings', array(substr($item, strlen($settingsPrefix))));
+        } elseif (strpos($item, $pagePrefix) === 0) {
+            $url = route('admin_page', array(substr($item, strlen($pagePrefix))));
+        } elseif (filter_var($item, FILTER_VALIDATE_URL)) {
+            $url = $item;
+        } else {
+            $url = route('admin_index', array($item));
+        }
+        $menu[$url] = $key;
+    }
 }

--- a/src/views/partials/menu_item.blade.php
+++ b/src/views/partials/menu_item.blade.php
@@ -14,12 +14,6 @@
 	</li>
 @else
 	<li class="item">
-		@if (strpos($key, $settingsPrefix) === 0)
-			<a href="{{route('admin_settings', array(substr($key, strlen($settingsPrefix))))}}">{{$item}}</a>
-		@elseif (strpos($key, $pagePrefix) === 0)
-			<a href="{{route('admin_page', array(substr($key, strlen($pagePrefix))))}}">{{$item}}</a>
-		@else
-			<a href="{{route('admin_index', array($key))}}">{{$item}}</a>
-		@endif
+		<a href="{{$key}}">{{$item}}</a>
 	</li>
 @endif


### PR DESCRIPTION
## Notes
- https://github.com/bemyguest/v3/pull/6604 depends on this

## Added support for the following examples:
#### 1. full string urls
example in `/config/administrator.php`:
```php
<?php
return [
	// ...
	'menu' => [
		// ...
		'Google' => 'http://google.com',
	],
];
```
#### 2. closures for using things that get loaded later on (like: `route()`, `auth()`, etc)
example in `/config/administrator.php`:
```php
<?php
return [
	// ...
	'menu' => [
		// ...
		'New Finance Refunds Page' => function(){
			return route('dashboard::finance::refunds.index');
		},
	],
];
```