### PR TITLE
Support closures in edit field values

### DIFF
--- a/src/Frozennode/Administrator/Fields/Factory.php
+++ b/src/Frozennode/Administrator/Fields/Factory.php
@@ -390,6 +390,9 @@ class Factory {
 			//iterate over each supplied edit field
 			foreach ($this->config->getOption('edit_fields') as $name => $options)
 			{
+                if (array_key_exists('value', $options) && is_callable($options['value'])) {
+                    $options['value'] = call_user_func($options['value']);
+                }
 				$fieldObject = $this->make($name, $options, $loadRelationships);
 				$this->editFields[$fieldObject->getOption('field_name')] = $fieldObject;
 			}


### PR DESCRIPTION
#### How to use:
example:
`config/administrator/users.php`
```php
<?php

return [
    /**
     * The editable fields
     */
    'edit_fields' => [
        // ... other fields
        'api_token' => [
            // ... other options
            'value' => function(){
                return bin2hex(random_bytes(30));
            },
            // ... other options
        ],
        // ... other fields
    ],
];
```
![image](https://user-images.githubusercontent.com/4393436/76180713-b9ca1100-61f9-11ea-81f0-200432c8d5de.png)

- https://github.com/bemyguest/v3/pull/6604/commits/ece52ccb49dd0d745389e4f82411a8223fb2287c depends on this