### PR TITLE
Add HasOneThrough relationship support for filters

### DIFF
--- a/src/Frozennode/Administrator/Fields/Factory.php
+++ b/src/Frozennode/Administrator/Fields/Factory.php
@@ -35,6 +35,7 @@ class Factory {
 		'belongs_to' => 'Frozennode\\Administrator\\Fields\\Relationships\\BelongsTo',
 		'belongs_to_many' => 'Frozennode\\Administrator\\Fields\\Relationships\\BelongsToMany',
 		'has_one' => 'Frozennode\\Administrator\\Fields\\Relationships\\HasOne',
+		'has_one_through' => 'Frozennode\\Administrator\\Fields\\Relationships\\HasOneThrough',
 		'has_many' => 'Frozennode\\Administrator\\Fields\\Relationships\\HasMany',
 
 	);
@@ -322,6 +323,10 @@ class Factory {
 		else if (is_a($related_model, $this->relationshipBase.'HasOne'))
 		{
 			return 'has_one';
+		}
+		else if (is_a($related_model, $this->relationshipBase.'HasOneThrough'))
+		{
+			return 'has_one_through';
 		}
 		else if (is_a($related_model, $this->relationshipBase.'HasMany'))
 		{

--- a/src/Frozennode/Administrator/Fields/Relationships/HasOneThrough.php
+++ b/src/Frozennode/Administrator/Fields/Relationships/HasOneThrough.php
@@ -1,0 +1,68 @@
+<?php
+namespace Frozennode\Administrator\Fields\Relationships;
+
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+class HasOneThrough extends Relationship {
+
+	/**
+	 * The relationship-type-specific defaults for the relationship subclasses to override
+	 *
+	 * @var array
+	 */
+	protected $relationshipDefaults = array(
+		'editable' => false,
+	);
+
+	/**
+	 * Builds a few basic options
+	 */
+	public function build()
+	{
+		parent::build();
+
+		$options = $this->suppliedOptions;
+		$model = $this->config->getDataModel();
+		$relationship = $model->{$options['field_name']}();
+		$related_model = $relationship->getRelated();
+
+		// Store keys needed for filtering through intermediate table
+		$options['table'] = $related_model->getTable();
+		$options['column'] = $related_model->getKeyName();
+		$options['through_table'] = $relationship->getParent()->getTable();
+		$options['local_key'] = $relationship->getLocalKeyName();
+		$options['first_key'] = $relationship->getFirstKeyName();
+		$options['foreign_key'] = $relationship->getForeignKeyName();
+		$options['second_local_key'] = $relationship->getSecondLocalKeyName();
+
+		$this->suppliedOptions = $options;
+	}
+
+	/**
+	 * Filters a query object with this item's data by joining through intermediate table
+	 *
+	 * @param \Illuminate\Database\Query\Builder	$query
+	 * @param array|null							$selects
+	 *
+	 * @return void
+	 */
+	public function filterQuery(QueryBuilder &$query, &$selects = null)
+	{
+		parent::filterQuery($query, $selects);
+
+		if (!$this->getOption('value'))
+		{
+			return;
+		}
+
+		$mainTable = $this->config->getDataModel()->getTable();
+		$throughTable = $this->getOption('through_table');
+		$localKey = $this->getOption('local_key');
+		$firstKey = $this->getOption('first_key');
+		$secondLocalKey = $this->getOption('second_local_key');
+
+		// Join through intermediate table and filter by final relationship
+		$query->join($throughTable, $mainTable . '.' . $localKey, '=', $throughTable . '.' . $firstKey)
+			  ->where($throughTable . '.' . $secondLocalKey, '=', $this->getOption('value'));
+	}
+}

--- a/src/views/templates/filters.php
+++ b/src/views/templates/filters.php
@@ -73,6 +73,17 @@
 				<!-- /ko -->
 			<!-- /ko -->
 
+			<!-- ko if: type === 'has_one_through' -->
+				<div class="loader" data-bind="visible: loadingOptions"></div>
+
+				<!-- ko if: autocomplete -->
+				<input type="hidden" data-bind="value: value, attr: {id: field_id}, select2Remote: {field: field_name, type: 'filter', filterIndex: $index()}"/>
+				<!-- /ko -->
+				<!-- ko ifnot: autocomplete -->
+				<input type="hidden" data-bind="value: value, attr: {id: field_id}, select2: {data: {results: $root.listOptions[field_name]}}" />
+				<!-- /ko -->
+			<!-- /ko -->
+
 			<!-- ko if: type === 'belongs_to_many' -->
 				<div class="loader" data-bind="visible: loadingOptions"></div>
 


### PR DESCRIPTION
## Overview

Adds support for Laravel's `HasOneThrough` relationships in Administrator filters, enabling filtering through intermediate tables.

## Changes

### 1. Factory.php
- Recognize `HasOneThrough` relationships and return `has_one_through` type
- Add mapping: `'has_one_through' => HasOneThrough::class`

### 2. HasOneThrough.php (new file)
- Complete relationship field class implementation
- `build()` method: Extract keys from HasOneThrough relationship
- `filterQuery()` method: Join through intermediate table and filter by final relationship

### 3. filters.php template  
- Add frontend rendering for `has_one_through` type
- Uses same select2 autocomplete dropdown as `belongs_to`

## Implementation Details

**How it works:**
- Treats HasOneThrough as single-selection relationship (like BelongsTo)
- Joins through intermediate table using relationship keys
- Filters by final relationship's foreign key

**Example use case (from v3):**
```php
// TicketOrder model
public function operator(): HasOneThrough
{
    return $this->hasOneThrough(
        Supplier::class,
        ProductInventory::class,
        'id', 'id', 'product_inventory_id', 'supplier_id'
    );
}

// Config filter
'operator' => [
    'type' => 'relationship',
    'name_field' => 'display_name',
    'autocomplete' => true,
],
```

**Generated SQL:**
```sql
INNER JOIN product_inventories 
  ON ticket_orders.product_inventory_id = product_inventories.id
WHERE product_inventories.supplier_id = ?
```

## Testing

Tested in bemyguest/v3 project:
- ✅ Filter dropdown renders correctly
- ✅ Autocomplete search works
- ✅ Query joins through intermediate table
- ✅ Filtering returns correct results

Related v3 PR: bemyguest/v3#18160

## Version

Suggest releasing as **v6.1.2** (patch) or **v6.2.0** (minor feature)